### PR TITLE
frameworks: add alwaysRequestAudioFocusForCalls overlay

### DIFF
--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -1843,6 +1843,7 @@
   <java-symbol type="string" name="config_deviceKeyHandlerLib" />
   <java-symbol type="string" name="config_deviceKeyHandlerClass" />
   <java-symbol type="bool" name="config_batterySdCardAccessibility" />
+  <java-symbol type="bool" name="config_alwaysRequestAudioFocusForCalls" />
 
   <!-- Telephony -->
   <java-symbol type="bool" name="config_smsSamsungCdmaAlternateMessageIDEncoding" />


### PR DESCRIPTION
https://github.com/CyanogenMod/android_frameworks_base/commit/64421f7d333881c5a34c849bae05bb182c2a18f8

fixing error:
frameworks/opt/telephony/src/java/com/android/internal/telephony/CallManager.java:538: cannot find symbol
symbol  : variable config_alwaysRequestAudioFocusForCalls
