### PR TITLE
frameworks: add alwaysRequestAudioFocusForCalls overlay

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -1574,4 +1574,10 @@
 
     <!-- Ignored sms packages -->
     <string-array name="config_ignored_sms_packages"></string-array>
++
+    <!-- Whether to always request audio focus for incoming calls.
+         Default is false: silent and vibrate modes will not request audio focus.
+         true: all incoming calls will request audio focus (overriding any active music)
+    -->
+     <bool name="config_alwaysRequestAudioFocusForCalls">false</bool>
 </resources>

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -1574,7 +1574,7 @@
 
     <!-- Ignored sms packages -->
     <string-array name="config_ignored_sms_packages"></string-array>
-+
+
     <!-- Whether to always request audio focus for incoming calls.
          Default is false: silent and vibrate modes will not request audio focus.
          true: all incoming calls will request audio focus (overriding any active music)


### PR DESCRIPTION
https://github.com/CyanogenMod/android_frameworks_base/commit/64421f7d333881c5a34c849bae05bb182c2a18f8

fixing error:
frameworks/opt/telephony/src/java/com/android/internal/telephony/CallManager.java:538: cannot find symbol
symbol  : variable config_alwaysRequestAudioFocusForCalls
