### PR TITLE
Support NoGapps style package signature faking

### DIFF
--- a/core/java/android/content/pm/PackageParser.java
+++ b/core/java/android/content/pm/PackageParser.java
@@ -609,10 +609,23 @@ public class PackageParser {
             }
         }
         if ((flags&PackageManager.GET_SIGNATURES) != 0) {
-           int N = (p.mSignatures != null) ? p.mSignatures.length : 0;
-           if (N > 0) {
-                pi.signatures = new Signature[N];
-                System.arraycopy(p.mSignatures, 0, pi.signatures, 0, N);
+            boolean handledFakeSignature = false;
+            try {
+                if (p.requestedPermissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE") && p.mAppMetaData != null
+                        && p.mAppMetaData.get("fake-signature") instanceof String) {
+                    pi.signatures = new Signature[] {new Signature(p.mAppMetaData.getString("fake-signature"))};
+                    handledFakeSignature = true;
+                }
+            } catch (Throwable t) {
+                // We should never die because of any failures, this is system code!
+                Log.w("PackageParser.FAKE_PACKAGE_SIGNATURE", t);
+            }
+            if (!handledFakeSignature) {
+                int N = (p.mSignatures != null) ? p.mSignatures.length : 0;
+                if (N > 0) {
+                    pi.signatures = new Signature[N];
+                    System.arraycopy(p.mSignatures, 0, pi.signatures, 0, N);
+                }
             }
         }
         return pi;

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -1827,6 +1827,13 @@
         android:protectionLevel="normal"
         android:label="@string/permlab_getPackageSize"
         android:description="@string/permdesc_getPackageSize" />
+        
+    <!-- Allows an application to change the package signature as seen by applications -->
+    <permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"
+                android:permissionGroup="android.permission-group.SYSTEM_TOOLS"
+                android:protectionLevel="dangerous"
+                android:label="@string/permlab_fakePackageSignature"
+                android:description="@string/permdesc_fakePackageSignature" />
 
     <!-- @deprecated No longer useful, see
          {@link android.content.pm.PackageManager#addPackageToPreferred}

--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -1284,6 +1284,11 @@
     <string name="permlab_getPackageSize">measure app storage space</string>
     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
     <string name="permdesc_getPackageSize">Allows the app to retrieve its code, data, and cache sizes</string>
+    
+    <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+    <string name="permlab_fakePackageSignature">mimic package signature</string>
+    <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+    <string name="permdesc_fakePackageSignature">Allows the app to use mimic another app\'s package signature.</string>
 
     <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
     <string name="permlab_installPackages">directly install apps</string>


### PR DESCRIPTION
Unfortunately due to GMSCore libraries for clients carrying out signature checks on the GMS app, users are not able to use open source equivalents, and are being strong-armed (by apps) into using non-free libraries for these functions. 

NoGapps is an open source implementation of these libraries. Unfortunately, a patch like this is necessary in order to permit apps to be convinced they are talking to the closed-source GMSCore. As this "DRM" is implemented at app-level, it's possible to do this, without the Android OS itself being "fooled" by the faked signatures. 

Originates from: https://github.com/microg/android_packages_apps_GmsCore
